### PR TITLE
Use KAC CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker
 
-RUN apk add parallel
+RUN wget https://github.com/keboola/keboola-as-code/releases/download/v2.12.1/keboola-cli_2.12.1_linux_amd64.apk
+RUN apk add --allow-untrusted ./keboola-cli_2.12.1_linux_amd64.apk
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM docker
 
-RUN wget https://github.com/keboola/keboola-as-code/releases/download/v2.12.1/keboola-cli_2.12.1_linux_amd64.apk
-RUN apk add --allow-untrusted ./keboola-cli_2.12.1_linux_amd64.apk
+ARG CLI_VERSION="2.12.1"
+
+RUN echo "https://cli-dist.keboola.com/apk" | tee -a /etc/apk/repositories
+RUN wget -P /etc/apk/keys/ https://cli-dist.keboola.com/apk/keboola.rsa.pub
+RUN apk update && apk add keboola-cli=$CLI_VERSION
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker
 
-ARG CLI_VERSION="2.12.1"
+ARG CLI_VERSION="2.12.2"
 
 RUN echo "https://cli-dist.keboola.com/apk" | tee -a /etc/apk/repositories
 RUN wget -P /etc/apk/keys/ https://cli-dist.keboola.com/apk/keboola.rsa.pub

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Run KBC configs'
 description: 'Run KBC configs in parallel and verify that all were successful.'
 author: 'Keboola'
 inputs:
+  host:
+    description: 'Storage API host.'
+    required: false
+    default: 'connection.keboola.com'
   token:
     description: 'Storage API token.'
     required: true
@@ -18,6 +22,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.host }}
     - ${{ inputs.token }}
     - ${{ inputs.componentId }}
     - ${{ inputs.tag }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,19 @@
 #!/bin/sh -l
 set -e
 
-if [ $# -lt 3 ]
+if [ $# -lt 4 ]
 then
   echo "Some parameters are missing"
   exit 1
 fi
-export KBC_STORAGE_TOKEN=$1
-export COMPONENT_ID=$2
-export TAG=$3
-CONFIGS=$4
 
-docker pull -q quay.io/keboola/syrup-cli:latest
-TASK='
-  echo "Running config {} with tag $TAG ..." &&
-  docker run --rm -e KBC_STORAGE_TOKEN quay.io/keboola/syrup-cli:latest run-job $COMPONENT_ID {} $TAG &&
-  echo "Config {} OK"
-'
-parallel --env COMPONENT_ID --env TAG --lb -j 0 --halt now,fail=1 "$TASK" ::: $CONFIGS
-echo "OK"
+HOST=$1
+TOKEN=$2
+COMPONENT=$3
+TAG=$4
+for id in $5
+do
+  JOBS="${JOBS} $COMPONENT/$id@$TAG"
+done
+
+kbc remote job run --storage-api-host $HOST --storage-api-token $TOKEN $JOBS


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PSGO-55

```
$ docker build -t action-run-configs-parallel .
$ docker run action-run-configs-parallel connection.keboola.com <token> keboola.runner-config-test 1.2.1 'unknown-config-id-a unknown-confing-id-b'
Starting 2 jobs.
Some jobs failed, see below.
Error:
- Job "keboola.runner-config-test/unknown-config-id-a@1.2.1" failed to start: jobs queue api error[400]: Cannot resolve job parameters: Configuration unknown-config-id-a not found.
- Job "keboola.runner-config-test/unknown-confing-id-b@1.2.1" failed to start: jobs queue api error[400]: Cannot resolve job parameters: Configuration unknown-confing-id-b not found.
```

Vyzkoušeno i na QV1, stejný output