### PR TITLE
Skip command if there is no config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,8 @@ do
   JOBS="${JOBS} $COMPONENT/$id@$TAG"
 done
 
-kbc remote job run --storage-api-host $HOST --storage-api-token $TOKEN $JOBS
+if [ -z "$JOBS" ]; then
+  echo "No config specified."
+else
+  kbc remote job run --storage-api-host "$HOST" --storage-api-token "$TOKEN" $JOBS
+fi


### PR DESCRIPTION
Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1678713693248439

Changes:
- The CLI command is skipped if there is no config configured, so the storage API token is not required.

----------------

**Manually tested:**

CI with test configs:
https://github.com/keboola/db-extractor-mysql/pull/167

CI without test configs:
https://github.com/keboola/snowflake-transformation/pull/20
